### PR TITLE
Fix the table expected error and add a little delay after each image

### DIFF
--- a/lua/hologram-math-preview/equations.lua
+++ b/lua/hologram-math-preview/equations.lua
@@ -29,6 +29,11 @@ M.add = function(buf, sr, sc, er, ec)
 
 	eq.location = { sr, sc, er, ec }
 
+  local line_count = vim.api.nvim_buf_line_count(0)
+  if sr+1 == line_count then
+      vim.api.nvim_buf_set_lines(0, -1, -1, false, {""})
+    end
+
 	--set extmark
 	vim.api.nvim_buf_set_extmark(buf, M.namespace, sr, sc, { id = eq.id, end_row = er, end_col = ec })
 

--- a/lua/hologram-math-preview/init.lua
+++ b/lua/hologram-math-preview/init.lua
@@ -40,6 +40,7 @@ function hologram_math_preview.show_all_eq()
 	-- print(vim.inspect(equations.equations[1].current_equation))
 	for _, eq in ipairs(equations.equations) do
 		createlatex.show_latex_equation_image(eq)
+    vim.wait(10)
 	end
 end
 

--- a/lua/hologram-math-preview/markdowncapture.lua
+++ b/lua/hologram-math-preview/markdowncapture.lua
@@ -24,9 +24,10 @@ function M.extract_all_equations()
 	local language_tree = vim.treesitter.get_parser(buf, "latex")
 	local syntax_tree = language_tree:parse()
 	local root = syntax_tree[1]:root()
+  local start_row, _, end_row, _ = root:range()
 	local inline_formula_query = vim.treesitter.query.parse("latex", "(inline_formula) @inf")
 
-	for id, match, metadata in inline_formula_query:iter_matches(root, buf, root:start(), root:end_()) do
+	for id, match, metadata in inline_formula_query:iter_matches(root, buf, start_row, end_row) do
 		local eq = {}
 		eq.equation = vim.treesitter.get_node_text(match[1], buf)
 		local ir, ic, fr, fc = match[1]:range()


### PR DESCRIPTION
When trying to launch the show_all_eq function the error table expected is occuring

```
Kindly wait until all equations are parsed...                                                           
E5108: Error executing lua ...9QAs/usr/share/nvim/runtime/lua/vim/treesitter/query.lua:760: table expected
stack traceback:
        [C]: in function '_rawquery'
        ...9QAs/usr/share/nvim/runtime/lua/vim/treesitter/query.lua:760: in function 'iter_matches'
        ...eview.nvim/lua/hologram-math-preview/markdowncapture.lua:29: in function 'extract_all_equations'
        ...ram-math-preview.nvim/lua/hologram-math-preview/init.lua:37: in function 'show_all_eq'
        [string ":lua"]:1: in main chunk
Press ENTER or type command to continue
```

The iter_matches was getting wrong parameters.

To have a better images placement I've added a little timer, few times they just place wrongly. I suspect, the display function of hologram.nvim to not have finished the displaying and returning true. I tried to make a queue checking for the return value of the display function but with no success. Only a little timer solved that. It will probably need a better way tho.

Also when a latex expression is on the last line of the buffer. hologram.nvim only display gibberish (probably because expressions are display with index+1). So now if a latex expression is detected at the last line, a new one is created when the equations are added.